### PR TITLE
add Parcelable method

### DIFF
--- a/app/src/main/java/com/example/calculator/HomeWorkDisplayInfo.java
+++ b/app/src/main/java/com/example/calculator/HomeWorkDisplayInfo.java
@@ -1,0 +1,51 @@
+package com.example.calculator;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class HomeWorkDisplayInfo implements Parcelable {
+
+   public String displayInfo;
+   public String otherInfo;
+
+   public HomeWorkDisplayInfo(String displayInfo, String otherInfo){
+       this.displayInfo = displayInfo;
+       this.otherInfo = otherInfo;
+   }
+
+
+    protected HomeWorkDisplayInfo(Parcel in) {
+        displayInfo = in.readString();
+        otherInfo = in.readString();
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.displayInfo);
+        dest.writeString(this.otherInfo);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator CREATOR = new Creator() {
+        @Override
+        public HomeWorkDisplayInfo createFromParcel(Parcel in) {
+            return new HomeWorkDisplayInfo(in);
+        }
+
+        @Override
+        public HomeWorkDisplayInfo[] newArray(int size) {
+            return new HomeWorkDisplayInfo[size];
+        }
+    };
+   public String getDisplayInfo() { return displayInfo;}
+
+   public void setDisplayInfo(String displayInfo) {this.displayInfo = displayInfo;}
+
+   public String getOtherInfo() { return otherInfo;}
+
+   public void setOtherInfo(String otherInfo) {this.otherInfo = otherInfo;}
+}

--- a/app/src/main/java/com/example/calculator/MainActivityCalculator.java
+++ b/app/src/main/java/com/example/calculator/MainActivityCalculator.java
@@ -1,14 +1,23 @@
 package com.example.calculator;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.view.View;
+import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
+
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.annotation.SuppressLint;
+
 import androidx.annotation.NonNull;
 
 public class MainActivityCalculator extends AppCompatActivity {
+
+    private Button parcelableMoveDigitButton;
 
     private Calculator calculator;        // object of Calculator class
     private TextView inputValue1TextView; // for TextView ID - input_value_1
@@ -20,14 +29,14 @@ public class MainActivityCalculator extends AppCompatActivity {
     private double numberTwo;             // second number
     private String operationString;       // current operation
     private static int MAX_CHARACTERS = 12;
-    private static final String FIRST_NUMBER_KEY       = "first_number";
-    private static final String SECOND_NUMBER_KEY      = "second_number";
-    private static final String OPERATION_KEY          = "operation";
-    private static final String FINAL_RESULT_KEY       = "final_result";
+    private static final String FIRST_NUMBER_KEY = "first_number";
+    private static final String SECOND_NUMBER_KEY = "second_number";
+    private static final String OPERATION_KEY = "operation";
+    private static final String FINAL_RESULT_KEY = "final_result";
     private static final String COMPLETE_OPERATION_KEY = "complete_operation";
-    private static final String OPERATION_STRING_KEY   = "operation_string";
-    private static final String NUMBER_ONE_KEY         = "number_one";
-    private static final String NUMBER_TWO_KEY         = "number_two";
+    private static final String OPERATION_STRING_KEY = "operation_string";
+    private static final String NUMBER_ONE_KEY = "number_one";
+    private static final String NUMBER_TWO_KEY = "number_two";
 
 
     private enum operator {
@@ -47,7 +56,7 @@ public class MainActivityCalculator extends AppCompatActivity {
         operationString = MainActivityCalculator.operator.NULL.name();
 
 
-    //    Implementation of saved instance state
+        //    Implementation of saved instance state
         if (savedInstanceState != null) {
             inputValue1TextView.setText(savedInstanceState.getString(FIRST_NUMBER_KEY, ""));
             inputValue2TextView.setText(savedInstanceState.getString(SECOND_NUMBER_KEY, ""));
@@ -58,10 +67,30 @@ public class MainActivityCalculator extends AppCompatActivity {
             numberOne = savedInstanceState.getDouble(NUMBER_ONE_KEY, 0);
             numberTwo = savedInstanceState.getDouble(NUMBER_TWO_KEY, 0);
         }
+
+        parcelableMoveDigitButton = findViewById(R.id.parcelable_move_digit_button);
+
+        // Parcelable transfer
+        parcelableMoveDigitButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+
+                // create HomeWorkDisplayInfo object
+                HomeWorkDisplayInfo homeWorkDisplayInfo = new HomeWorkDisplayInfo(finalResultTextView.getText().toString(),
+                        completeOperation.getText().toString());
+
+                // create intent to MainActivityCalculator class
+                Intent intent = new Intent(MainActivityCalculator.this, MoveDigit.class);
+                // Add HomeWorkDisplayInfo data as extras to the intent
+                intent.putExtra("Data", homeWorkDisplayInfo);
+                startActivity(intent);
+            }
+        });
+
     }
 
     //    implementation of Saved instance state
-        @Override
+    @Override
     protected void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putString(FIRST_NUMBER_KEY, inputValue1TextView.getText().toString());
@@ -106,7 +135,7 @@ public class MainActivityCalculator extends AppCompatActivity {
     @SuppressLint("NonConstantResourceId")
     public void onNumClick(View view) {
         if (!finalResultTextView.getText().toString().equals("")) {
-           //  onClearClick(view);
+            //  onClearClick(view);
         }
         switch (view.getId()) {
             case R.id.button_1_text_view:
@@ -194,14 +223,16 @@ public class MainActivityCalculator extends AppCompatActivity {
 
     }
 
+
     public void onEqualsClick(View view) {
-    //     handle equals click
+        //     handle equals click
         if (inputValue1TextView.getText().toString().equals("") || operatorTextView.getText().toString().equals("") || inputValue2TextView.getText().toString().equals("")) {
             Toast.makeText(this, "Введите число или операцию", Toast.LENGTH_LONG).show();
         } else {
             numberOne = Double.parseDouble(inputValue1TextView.getText().toString());
             numberTwo = Double.parseDouble(inputValue2TextView.getText().toString());
             String operation;
+
 
             switch (MainActivityCalculator.operator.valueOf(operationString)) {
                 case ADD:
@@ -299,5 +330,6 @@ public class MainActivityCalculator extends AppCompatActivity {
         backspace = backspace.substring(0, backspace.length() - 1);
         view.setText(backspace);
     }
+
 
 }

--- a/app/src/main/java/com/example/calculator/MoveDigit.java
+++ b/app/src/main/java/com/example/calculator/MoveDigit.java
@@ -1,0 +1,36 @@
+package com.example.calculator;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+public class
+MoveDigit extends AppCompatActivity {
+
+    public static final String DISPLAY_KEY = "Data";
+    private TextView displayInfoTextView, otherInfoTextView2;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_move_digit);
+
+        displayInfoTextView = findViewById(R.id.move_digit_text_view);
+        otherInfoTextView2 = findViewById(R.id.move_digit_text_view2);
+
+        // receive the parcelable data from SourceMoveDigit
+        Bundle data = getIntent().getExtras();
+        HomeWorkDisplayInfo homeWorkDisplayInfo = (HomeWorkDisplayInfo) data.getParcelable(DISPLAY_KEY);
+
+        String displayInfo = homeWorkDisplayInfo.getDisplayInfo();
+        String otherInfo = homeWorkDisplayInfo.getOtherInfo();
+
+        Log.i("SourceMoveDigit", "display info: " + displayInfo + " otherInfo: " + otherInfo);
+
+        displayInfoTextView.setText(displayInfo);
+        otherInfoTextView2.setText(otherInfo);
+    }
+}

--- a/app/src/main/java/com/example/calculator/SourceMoveDigit.java
+++ b/app/src/main/java/com/example/calculator/SourceMoveDigit.java
@@ -1,0 +1,41 @@
+package com.example.calculator;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class SourceMoveDigit extends AppCompatActivity {
+
+    private Button parcelableMoveDigitButton;
+
+    @Override
+    protected void onCreate( Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_calculator_constraint_layout);
+
+        parcelableMoveDigitButton = findViewById(R.id.parcelable_move_digit_button);
+
+        // Parcelable transfer
+        parcelableMoveDigitButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+
+                // create HomeWorkDisplayInfo object
+                HomeWorkDisplayInfo homeWorkDisplayInfo = new HomeWorkDisplayInfo("77777", "33333");
+                // create intent to MainActivityCalculator class
+                Intent intent = new Intent(SourceMoveDigit.this, MoveDigit.class);
+                // Add HomeWorkDisplayInfo data as extras to the intent
+                intent.putExtra("Data", homeWorkDisplayInfo);
+                startActivity(intent);
+            }
+        });
+
+
+
+
+        }
+    }
+

--- a/app/src/main/res/layout/activity_calculator_constraint_layout.xml
+++ b/app/src/main/res/layout/activity_calculator_constraint_layout.xml
@@ -73,6 +73,13 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/display_calculator_image_view" />
 
+    <Button
+        android:id="@+id/parcelable_move_digit_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/text_move_digit"
+        app:layout_constraintTop_toBottomOf="@+id/complete_operation_text_view"/>
+
     <TextView
         android:id="@+id/button_percent_text_view"
         style="@style/style_buttons_digit"

--- a/app/src/main/res/layout/activity_move_digit.xml
+++ b/app/src/main/res/layout/activity_move_digit.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <TextView
+        android:id="@+id/move_digit_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        style="@style/style_complete_operation_display"
+        android:textAlignment="center"/>
+    <TextView
+        android:id="@+id/move_digit_text_view2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/move_digit_text_view"
+        style="@style/style_complete_operation_display"
+        android:textAlignment="center"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- I did the processing of all the buttons.

- Information from the calculator screen is now saved when the display orientation is changed.

- Created a button to transfer the values of the calculation result and the text of operations to a new activity using the Parcelable interface.

- I have achieved the exclusion of an erroneous set for calculating operations.
- (to clear the screen, press < C >, the < % > button - calculates the remainder of the division)

![image](https://user-images.githubusercontent.com/51420252/147475870-08557a51-ff03-4750-b666-81de53071ddf.png)

![image](https://user-images.githubusercontent.com/51420252/147475943-54f23f5a-e476-44bf-845e-0d528ed69957.png)

![image](https://user-images.githubusercontent.com/51420252/147475976-b9f76ed6-ccc6-4b06-9efd-b3e2d588fb81.png)
